### PR TITLE
Add GitHub Actions for phpcs and phplint

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+- package-ecosystem: "github-actions"
+  directory: "/"
+  schedule:
+    interval: monthly

--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -1,0 +1,43 @@
+name: PHP Tests
+
+on:
+  push:
+    branches:
+      - main
+      - release/*
+  pull_request:
+    branches:
+      - main
+      - release/*
+
+jobs:
+  lint:
+    name: Lint and Code Style
+    runs-on: ${{ matrix.os }}
+
+    strategy:
+      fail-fast: false
+      matrix:
+        php: ['8.1', '8.2', '8.3']
+        os: ['ubuntu-latest']
+
+    steps:
+      - name: Checkout code base
+        uses: actions/checkout@v4
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ matrix.php }}
+          tools: phpcs
+
+      - name: Setup dependencies
+        run: composer require -n --no-progress overtrue/phplint
+
+      - name: PHP Lint
+        if: success() || matrix.allow_failure
+        run: ./vendor/bin/phplint -n --exclude={^vendor/.*} -- .
+
+      - name: PHP CodeSniffer
+        if: success() || matrix.allow_failure
+        run: phpcs -wps --colors

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+# Artifacts from testing, linting, etc
+.phpunit.cache/
+.phplint.cache/

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0"?>
+<ruleset name="PHP_CodeSniffer">
+    <description>Sniff our code a while</description>
+
+    <file>configuration.php</file>
+    <file>application/</file>
+    <file>library/</file>
+
+    <exclude-pattern>vendor/*</exclude-pattern>
+
+    <arg value="wps"/>
+    <arg name="colors" />
+    <arg name="report-width" value="auto" />
+    <arg name="report-full" />
+    <arg name="report-gitblame" />
+    <arg name="report-summary" />
+    <arg name="encoding" value="UTF-8" />
+
+    <rule ref="PSR2">
+        <exclude name="PEAR.Commenting.FileComment.Missing"/>
+        <exclude name="PEAR.Commenting.ClassComment.Missing"/>
+        <exclude name="PEAR.Commenting.FunctionComment.Missing"/>
+    </rule>
+
+    <rule ref="PSR1.Classes.ClassDeclaration.MissingNamespace">
+        <exclude-pattern>*/application/views/helpers/*</exclude-pattern>
+    </rule>
+    <rule ref="Squiz.Classes.ValidClassName.NotCamelCaps">
+        <exclude-pattern>*/application/views/helpers/*</exclude-pattern>
+    </rule>
+
+    <rule ref="Generic.Files.LineLength">
+        <properties>
+            <property name="lineLimit" value="150"/>
+        </properties>
+    </rule>
+</ruleset>


### PR DESCRIPTION
Hi Nicolas, 

I added GitHub Action for phplint and phpcs. That way all contributors use the same Code Style.

The phpcs.xml is similar to what official Icinga Web repositories use.

There are some "findings" of course, but most can be fixed automatically with `phpcbf application library` 

Let me know if you have any feedback.

Regards,
Markus