### PR TITLE
Fix multi-provider group sync collisions + provider-level mapping strategy

### DIFF
--- a/application/controllers/AuthenticationController.php
+++ b/application/controllers/AuthenticationController.php
@@ -15,8 +15,8 @@ use Icinga\Module\Oidc\LoginFormModifierHelper;
 use Icinga\Module\Oidc\Model\Group;
 use Icinga\Module\Oidc\Model\GroupMembership;
 use Icinga\Module\Oidc\Model\Provider;
-use Icinga\User;
 use Icinga\Module\Oidc\Model\User as OidcUser;
+use Icinga\User;
 use Icinga\Util\StringHelper;
 use ipl\Html\Html;
 use ipl\Stdlib\Filter;
@@ -39,12 +39,10 @@ class AuthenticationController extends \Icinga\Controllers\AuthenticationControl
         parent::loginAction();
         LoginFormModifierHelper::init();
         $this->view->form = $this->view->form . "\n" . LoginFormModifierHelper::renderAfterForm();
-
     }
 
     public function realmAction()
     {
-
         $name = $this->params->getRequired("name");
 
         $authSuccess = false;
@@ -55,15 +53,16 @@ class AuthenticationController extends \Icinga\Controllers\AuthenticationControl
         if (!$provider->enabled) {
             throw new HttpException(405, "Provider not enabled");
         }
+
         try {
             $oidc = new OpenIDConnectClient($provider->url, $provider->appname, $provider->secret);
 
             // Register the post-login callback URL
-
             $scheme = $this->getRequest()->getScheme();
             if ($provider->enforce_scheme_https === true || $provider->enforce_scheme_https === 'y') {
                 $scheme = "https";
             }
+
             $oidcUrl = \ipl\Web\Url::fromPath('oidc/authentication/realm', ['name' => $name])
                 ->setIsExternal(true)
                 ->setHost($this->getRequest()->getHttpHost())
@@ -71,12 +70,16 @@ class AuthenticationController extends \Icinga\Controllers\AuthenticationControl
                 ->getAbsoluteUrl();
 
             $oidc->setRedirectURL($oidcUrl);
-            $relogin = Config::module('oidc')->get("experimental","relogin", "0") === "1";
 
+            $relogin = Config::module('oidc')->get("experimental", "relogin", "0") === "1";
             if ($relogin) {
-                setcookie("oidc-internalurl", $oidcUrl, time() + 60 * 60 * 24 * 3, str_replace("//","/",Icinga::app()->getRequest()->getBasePath()."/")); // needs to be a cookie to work after logout
+                setcookie(
+                    "oidc-internalurl",
+                    $oidcUrl,
+                    time() + 60 * 60 * 24 * 3,
+                    str_replace("//", "/", Icinga::app()->getRequest()->getBasePath() . "/")
+                ); // needs to be a cookie to work after logout
             }
-
 
             // Register what scopes you need.
             // Initiate the login process at the OP
@@ -88,12 +91,15 @@ class AuthenticationController extends \Icinga\Controllers\AuthenticationControl
 
             $redirect = "dashboard";
 
-
             if ($oidc->authenticate()) {
-
                 if (!empty($_COOKIE['oidc-redirect'])) {
                     $redirect = $_COOKIE['oidc-redirect'];
-                    setcookie("oidc-redirect", "", time() - 3600, str_replace("//","/",Icinga::app()->getRequest()->getBasePath()."/"));
+                    setcookie(
+                        "oidc-redirect",
+                        "",
+                        time() - 3600,
+                        str_replace("//", "/", Icinga::app()->getRequest()->getBasePath() . "/")
+                    );
                 }
 
                 $authSuccess = true;
@@ -110,8 +116,8 @@ class AuthenticationController extends \Icinga\Controllers\AuthenticationControl
                     $custom_username = $provider->custom_username;
                 } else {
                     $custom_username = $fallback_username;
-
                 }
+
                 if (isset($claims->{$custom_username}) && $claims->{$custom_username} !== "") {
                     $username = $claims->{$custom_username};
                 } else {
@@ -125,39 +131,36 @@ class AuthenticationController extends \Icinga\Controllers\AuthenticationControl
                         throw new HttpException(401, "Username not allowed for this provider");
                     }
                 }
+
                 if (session_status() == PHP_SESSION_ACTIVE) {
                     // Icinga wants to handle the session so we destroy ours
                     session_destroy();
                 }
-
             }
-
         } catch (\Throwable $e) {
             Logger::error($e->getMessage());
             Logger::error($e->getTraceAsString());
-
-
         }
 
-
         if ($authSuccess && $claims != null) {
-            $oidcUser = OidcUser::on(Database::get())->filter(Filter::equal('name', $username))->filter(Filter::equal('provider_id', $provider->id))->first();
+            $oidcUser = OidcUser::on(Database::get())
+                ->filter(Filter::equal('name', $username))
+                ->filter(Filter::equal('provider_id', $provider->id))
+                ->first();
+
             if ($oidcUser === null) {
                 $oidcUser = new OidcUser();
                 $oidcUser->name = $username;
                 if (isset($claims->email)) {
                     $oidcUser->email = $claims->email;
                 }
-
                 $oidcUser->provider_id = $provider->id;
                 $oidcUser->lastlogin = (new \DateTime());
                 $oidcUser->ctime = (new \DateTime());
                 $oidcUser->active = 'y';
                 $oidcUser->save();
-
             } else {
                 if (!$oidcUser->active) {
-
                     throw new HttpException(401, "User not enabled");
                 }
                 $oidcUser->lastlogin = (new \DateTime());
@@ -165,11 +168,11 @@ class AuthenticationController extends \Icinga\Controllers\AuthenticationControl
                     $oidcUser->email = $claims->email;
                 }
                 $oidcUser->save();
-
             }
-            $groupsSynclist = StringHelper::trimSplit($provider->syncgroups);
-            if (isset($claims->groups) && is_array($claims->groups)) {
 
+            $groupsSynclist = StringHelper::trimSplit($provider->syncgroups);
+
+            if (isset($claims->groups) && is_array($claims->groups)) {
                 if ($provider->required_groups !== null && $provider->required_groups !== "") {
                     $requiredGroups = StringHelper::trimSplit($provider->required_groups);
                     $hasRequiredGroup = count($this->filter_by_patterns($claims->groups, $requiredGroups)) > 0;
@@ -178,12 +181,15 @@ class AuthenticationController extends \Icinga\Controllers\AuthenticationControl
                     }
                 }
 
-
                 if (isset($provider->defaultgroup) && $provider->defaultgroup !== null && $provider->defaultgroup !== "") {
                     $claims->groups[] = $provider->defaultgroup;
                     $groupsSynclist[] = $provider->defaultgroup;
                 }
 
+                $groupMappingMode = Config::module('oidc')->get('groups', 'mapping_mode', 'shared');
+
+                // Keep a list of effective (mapped) group names so cleanup works for both shared and prefixed modes
+                $effectiveGroupNames = [];
 
                 foreach ($claims->groups as $key => $group) {
                     $groupname = $group;
@@ -196,25 +202,50 @@ class AuthenticationController extends \Icinga\Controllers\AuthenticationControl
                             break;
                         }
                     }
+
                     if (!$validGroup) {
                         unset($claims->groups[$key]);
                         continue;
                     }
 
+                    $effectiveGroupName = $groupname;
+
+                    if ($groupMappingMode === 'prefixed') {
+                        $prefix = $provider->group_name_prefix;
+
+                        if ($prefix === null || $prefix === '') {
+                            // Default prefix derived from provider name (sanitized) to avoid collisions by default
+                            $base = strtolower($provider->name);
+                            $base = preg_replace('/\s+/', '-', $base);
+                            $base = preg_replace('/[^a-z0-9_-]/', '', $base);
+                            $prefix = $base . ':';
+                        }
+
+                        $effectiveGroupName = $prefix . $groupname;
+                    }
+
+                    $effectiveGroupNames[] = $effectiveGroupName;
+
                     // IMPORTANT: group names are globally unique in the module DB schema (uq_oidc_group_name),
                     // so we must NOT scope the lookup by provider_id. Otherwise, a second provider will
                     // try to insert an already existing group and hit a duplicate key error.
-                    #$oidcGroup = Group::on(Database::get())->filter(Filter::equal('name', $groupname))->filter(Filter::equal('provider_id', $provider->id))->first();
-                    $oidcGroup = Group::on(Database::get())->filter(Filter::equal('name', $groupname))->first();
+                    $oidcGroup = Group::on(Database::get())
+                        ->filter(Filter::equal('name', $effectiveGroupName))
+                        ->first();
+
                     if ($oidcGroup === null) {
                         $oidcGroup = new Group();
-                        $oidcGroup->name = $groupname;
+                        $oidcGroup->name = $effectiveGroupName;
                         $oidcGroup->provider_id = $provider->id;
                         $oidcGroup->ctime = (new \DateTime());
                         $oidcGroup->save();
                     }
 
-                    $membership = GroupMembership::on(Database::get())->filter(Filter::equal('username', $oidcUser->name))->filter(Filter::equal('group_id', $oidcGroup->id))->first();
+                    $membership = GroupMembership::on(Database::get())
+                        ->filter(Filter::equal('username', $oidcUser->name))
+                        ->filter(Filter::equal('group_id', $oidcGroup->id))
+                        ->first();
+
                     if ($membership === null) {
                         $membership = new GroupMembership();
                         $membership->username = $oidcUser->name;
@@ -223,49 +254,61 @@ class AuthenticationController extends \Icinga\Controllers\AuthenticationControl
                         $membership->ctime = (new \DateTime());
                         $membership->save();
                     }
-
                 }
-                $memberships = GroupMembership::on(Database::get())->filter(Filter::equal('username', $oidcUser->name));
+
+                // Cleanup memberships for this user/provider only, based on effective group names
+                $memberships = GroupMembership::on(Database::get())
+                    ->filter(Filter::equal('username', $oidcUser->name))
+                    ->filter(Filter::equal('provider_id', $provider->id));
+
                 foreach ($memberships as $membership) {
-                    $group = Group::on(Database::get())->filter(Filter::equal('id', $membership->group_id))->first();
-                    if ($group !== null && !in_array($group->name, $claims->groups)) {
+                    $group = Group::on(Database::get())
+                        ->filter(Filter::equal('id', $membership->group_id))
+                        ->first();
+
+                    if ($group !== null && !in_array($group->name, $effectiveGroupNames)) {
                         $membership->delete();
                     }
                 }
-
             } else {
                 if ($provider->required_groups !== null && $provider->required_groups !== "") {
-                    //since there is an empty group claim we can't satisfy required_groups
+                    // since there is an empty group claim we can't satisfy required_groups
                     throw new HttpException(401, "User has not any required group for this provider");
                 }
             }
 
-
             $auth = Auth::getInstance();
 
             if (isset($oidcUser->mapped_local_user) && $oidcUser->mapped_local_user !== "" && $oidcUser->mapped_local_user !== null) {
-
                 $user = new User($oidcUser->mapped_local_user);
 
                 if (isset($oidcUser->mapped_backend) && $oidcUser->mapped_backend !== "" && $oidcUser->mapped_backend !== null) {
                     $backendName = $oidcUser->mapped_backend;
                     $backendType = Config::app('authentication')->getSection($backendName)->get('backend');
-
                 } else {
                     $backendName = null;
                     $backendType = null;
                 }
 
-                AuditHook::logActivity('login-oidc', sprintf("Oidc-user %s logged in as %s", $oidcUser->name, $oidcUser->mapped_local_user), null, $oidcUser->name);
-
+                AuditHook::logActivity(
+                    'login-oidc',
+                    sprintf("Oidc-user %s logged in as %s", $oidcUser->name, $oidcUser->mapped_local_user),
+                    null,
+                    $oidcUser->name
+                );
             } else {
                 $backendName = $provider->getUserBackendName();
                 $backendType = 'oidc';
                 $user = new User($oidcUser->name);
-                AuditHook::logActivity('login-oidc', sprintf("Oidc-user %s logged in as %s", $oidcUser->name, $oidcUser->name), null, $oidcUser->name);
 
-
+                AuditHook::logActivity(
+                    'login-oidc',
+                    sprintf("Oidc-user %s logged in as %s", $oidcUser->name, $oidcUser->name),
+                    null,
+                    $oidcUser->name
+                );
             }
+
             if (!$user->hasDomain()) {
                 $user->setDomain(Config::app()->get('authentication', 'default_domain'));
             }
@@ -280,8 +323,6 @@ class AuthenticationController extends \Icinga\Controllers\AuthenticationControl
         }
 
         $this->redirectNow("oidc/authentication/failed");
-
-
     }
 
     public function filter_by_patterns($array, $patterns)
@@ -304,7 +345,6 @@ class AuthenticationController extends \Icinga\Controllers\AuthenticationControl
         $div->add($html);
         $this->view->form = $this->view->form . $div;
         $this->_helper->viewRenderer->setRender('authentication/login', null, true);
-
     }
 
     public function oidcLogoutAction()
@@ -313,5 +353,4 @@ class AuthenticationController extends \Icinga\Controllers\AuthenticationControl
         $this->_helper->viewRenderer->setRender('authentication/login', null, true);
         $this->loginAction();
     }
-
 }

--- a/application/controllers/AuthenticationController.php
+++ b/application/controllers/AuthenticationController.php
@@ -186,7 +186,9 @@ class AuthenticationController extends \Icinga\Controllers\AuthenticationControl
                     $groupsSynclist[] = $provider->defaultgroup;
                 }
 
-                $groupMappingMode = Config::module('oidc')->get('groups', 'mapping_mode', 'shared');
+                $groupMappingStrategy = isset($provider->group_mapping_strategy) && $provider->group_mapping_strategy !== ''
+                    ? $provider->group_mapping_strategy
+                    : 'shared';
 
                 // Keep a list of effective (mapped) group names so cleanup works for both shared and prefixed modes
                 $effectiveGroupNames = [];
@@ -210,7 +212,7 @@ class AuthenticationController extends \Icinga\Controllers\AuthenticationControl
 
                     $effectiveGroupName = $groupname;
 
-                    if ($groupMappingMode === 'prefixed') {
+                    if ($groupMappingStrategy === 'prefixed') {
                         $prefix = $provider->group_name_prefix;
 
                         if ($prefix === null || $prefix === '') {

--- a/application/controllers/AuthenticationController.php
+++ b/application/controllers/AuthenticationController.php
@@ -201,7 +201,11 @@ class AuthenticationController extends \Icinga\Controllers\AuthenticationControl
                         continue;
                     }
 
-                    $oidcGroup = Group::on(Database::get())->filter(Filter::equal('name', $groupname))->filter(Filter::equal('provider_id', $provider->id))->first();
+                    // IMPORTANT: group names are globally unique in the module DB schema (uq_oidc_group_name),
+                    // so we must NOT scope the lookup by provider_id. Otherwise, a second provider will
+                    // try to insert an already existing group and hit a duplicate key error.
+                    #$oidcGroup = Group::on(Database::get())->filter(Filter::equal('name', $groupname))->filter(Filter::equal('provider_id', $provider->id))->first();
+                    $oidcGroup = Group::on(Database::get())->filter(Filter::equal('name', $groupname))->first();
                     if ($oidcGroup === null) {
                         $oidcGroup = new Group();
                         $oidcGroup->name = $groupname;

--- a/application/forms/BackendConfigForm.php
+++ b/application/forms/BackendConfigForm.php
@@ -30,5 +30,18 @@ class BackendConfigForm extends ConfigForm
             'label'         => $this->translate('Experimental Feature relogin'),
             'description'   => $this->translate('Redirect to the last used oidc login page, since this breaks the logic of the AuthenticationHook make sure to use it only if no other AuthenticationHook implements an onLogout function'),
         ]);
+        $this->addElement('select', 'groups_mapping_mode', [
+            'label'        => $this->translate('Group Mapping Mode'),
+            'description'  => $this->translate(
+                'Choose how group names are mapped into the OIDC database. '
+                . '"Shared (by name)" reuses existing groups across providers. '
+                . '"Prefixed" prefixes group names per provider to avoid name collisions.'
+            ),
+            'multiOptions' => [
+            'shared'   => $this->translate('Shared groups (by name)'),
+            'prefixed' => $this->translate('Prefixed group names per provider'),
+            ],
+            'value'        => 'shared',
+        ]);
     }
 }

--- a/application/forms/BackendConfigForm.php
+++ b/application/forms/BackendConfigForm.php
@@ -30,18 +30,5 @@ class BackendConfigForm extends ConfigForm
             'label'         => $this->translate('Experimental Feature relogin'),
             'description'   => $this->translate('Redirect to the last used oidc login page, since this breaks the logic of the AuthenticationHook make sure to use it only if no other AuthenticationHook implements an onLogout function'),
         ]);
-        $this->addElement('select', 'groups_mapping_mode', [
-            'label'        => $this->translate('Group Mapping Mode'),
-            'description'  => $this->translate(
-                'Choose how group names are mapped into the OIDC database. '
-                . '"Shared (by name)" reuses existing groups across providers. '
-                . '"Prefixed" prefixes group names per provider to avoid name collisions.'
-            ),
-            'multiOptions' => [
-            'shared'   => $this->translate('Shared groups (by name)'),
-            'prefixed' => $this->translate('Prefixed group names per provider'),
-            ],
-            'value'        => 'shared',
-        ]);
     }
 }

--- a/library/Oidc/Model/Provider.php
+++ b/library/Oidc/Model/Provider.php
@@ -75,10 +75,21 @@ class Provider extends DbModel
                 'label'=>'Required Groups',
                 'description'=>t('If this is set each user will need to be in one of these groups to be able to login, for example "icinga-login, ubuntu-admin", leave empty if you do not need this.'),
             ],
+            'group_mapping_strategy' => [
+                'fieldtype'    => 'select',
+                'label'        => t('Group Mapping Strategy'),
+                'description'  => t('Controls how group names are stored in the OIDC database. "Shared" reuses group names across providers. "Prefixed" prefixes group names per provider to avoid name collisions.'),
+                'required'     => true,
+                'multiOptions' => [
+                    'shared'   => t('Shared (by name)'),
+                    'prefixed' => t('Prefixed (per provider)'),
+                ],
+                'value'        => 'shared',
+            ],
             'group_name_prefix' => [
                 'fieldtype'    => 'text',
                 'label'        => t('Group Name Prefix'),
-                'description'  => t('Optional prefix used when group mapping mode is set to "Prefixed". Example: "admin:" turns "icinga-admins" into "admin:icinga-admins". Leave empty to default to the provider name.'),
+                'description'  => t('Optional prefix used when the provider group mapping strategy is set to "Prefixed". Example: "admin:" turns "icinga-admins" into "admin:icinga-admins". Leave empty to default to the provider name.'),
             ],
             'usernameblacklist'=>[
                 'fieldtype'=>'text',

--- a/library/Oidc/Model/Provider.php
+++ b/library/Oidc/Model/Provider.php
@@ -75,6 +75,11 @@ class Provider extends DbModel
                 'label'=>'Required Groups',
                 'description'=>t('If this is set each user will need to be in one of these groups to be able to login, for example "icinga-login, ubuntu-admin", leave empty if you do not need this.'),
             ],
+            'group_name_prefix' => [
+                'fieldtype'    => 'text',
+                'label'        => t('Group Name Prefix'),
+                'description'  => t('Optional prefix used when group mapping mode is set to "Prefixed". Example: "admin:" turns "icinga-admins" into "admin:icinga-admins". Leave empty to default to the provider name.'),
+            ],
             'usernameblacklist'=>[
                 'fieldtype'=>'text',
                 'label'=>'Username Blacklist',

--- a/schema/mysql-upgrades/0.6.1.sql
+++ b/schema/mysql-upgrades/0.6.1.sql
@@ -1,0 +1,4 @@
+ALTER TABLE tbl_provider ADD COLUMN group_name_prefix varchar(255) DEFAULT NULL;
+
+INSERT INTO tbl_schema (version, timestamp, success, reason)
+VALUES ('0.6.1', UNIX_TIMESTAMP() * 1000, 'y', NULL);

--- a/schema/mysql-upgrades/0.6.2.sql
+++ b/schema/mysql-upgrades/0.6.2.sql
@@ -1,0 +1,4 @@
+ALTER TABLE tbl_provider ADD COLUMN group_mapping_strategy varchar(16) NOT NULL DEFAULT 'shared';
+
+INSERT INTO tbl_schema (version, timestamp, success, reason)
+VALUES ('0.6.2', UNIX_TIMESTAMP() * 1000, 'y', NULL);

--- a/schema/mysql.schema.sql
+++ b/schema/mysql.schema.sql
@@ -20,6 +20,7 @@ CREATE TABLE tbl_provider (
     textcolor  varchar(255) NOT NULL,
     caption  varchar(255) NOT NULL,
     custom_username  varchar(255) DEFAULT NULL,
+    group_name_prefix varchar(255) DEFAULT NULL,
     enforce_scheme_https enum ('y', 'n') DEFAULT 'n' NOT NULL,
     azure_groups enum ('y', 'n') DEFAULT 'n' NOT NULL,
     enabled        enum ('y', 'n')  DEFAULT 'n' NOT NULL,

--- a/schema/mysql.schema.sql
+++ b/schema/mysql.schema.sql
@@ -21,6 +21,7 @@ CREATE TABLE tbl_provider (
     caption  varchar(255) NOT NULL,
     custom_username  varchar(255) DEFAULT NULL,
     group_name_prefix varchar(255) DEFAULT NULL,
+    group_mapping_strategy varchar(16) NOT NULL DEFAULT 'shared',
     enforce_scheme_https enum ('y', 'n') DEFAULT 'n' NOT NULL,
     azure_groups enum ('y', 'n') DEFAULT 'n' NOT NULL,
     enabled        enum ('y', 'n')  DEFAULT 'n' NOT NULL,
@@ -90,6 +91,6 @@ CREATE TABLE tbl_schema (
 
 
 INSERT INTO tbl_schema (version, timestamp, success, reason)
-VALUES ('0.6.0', UNIX_TIMESTAMP() * 1000, 'y', NULL);
+VALUES ('0.6.2', UNIX_TIMESTAMP() * 1000, 'y', NULL);
 
 

--- a/schema/pgsql-upgrades/0.6.1.sql
+++ b/schema/pgsql-upgrades/0.6.1.sql
@@ -1,0 +1,4 @@
+ALTER TABLE tbl_provider ADD COLUMN group_name_prefix character varying(255) DEFAULT NULL;
+
+INSERT INTO tbl_schema (version, "timestamp", success, reason)
+VALUES ('0.6.1', CURRENT_TIMESTAMP, 'y', NULL);

--- a/schema/pgsql-upgrades/0.6.2.sql
+++ b/schema/pgsql-upgrades/0.6.2.sql
@@ -1,0 +1,4 @@
+ALTER TABLE tbl_provider ADD COLUMN group_mapping_strategy character varying(16) NOT NULL DEFAULT 'shared';
+
+INSERT INTO tbl_schema (version, "timestamp", success, reason)
+VALUES ('0.6.2', CURRENT_TIMESTAMP, 'y', NULL);

--- a/schema/pgsql.schema.sql
+++ b/schema/pgsql.schema.sql
@@ -22,6 +22,7 @@ CREATE TABLE tbl_provider (
     azure_groups boolenum DEFAULT 'n' NOT NULL,
     custom_username character varying(255) DEFAULT NULL,
     group_name_prefix character varying(255) DEFAULT NULL,
+    group_mapping_strategy character varying(16) NOT NULL DEFAULT 'shared',
     enforce_scheme_https boolenum DEFAULT 'n' NOT NULL,
     enabled  boolenum DEFAULT 'n' NOT NULL,
     ctime  bigint DEFAULT NULL,
@@ -135,5 +136,5 @@ CREATE TABLE tbl_schema (
 
 
 INSERT INTO tbl_schema (version, "timestamp", success, reason)
-VALUES ('0.6.0', CURRENT_TIMESTAMP, 'y', NULL);
+VALUES ('0.6.2', CURRENT_TIMESTAMP, 'y', NULL);
 

--- a/schema/pgsql.schema.sql
+++ b/schema/pgsql.schema.sql
@@ -21,6 +21,7 @@ CREATE TABLE tbl_provider (
     caption  character varying(255) NOT NULL,
     azure_groups boolenum DEFAULT 'n' NOT NULL,
     custom_username character varying(255) DEFAULT NULL,
+    group_name_prefix character varying(255) DEFAULT NULL,
     enforce_scheme_https boolenum DEFAULT 'n' NOT NULL,
     enabled  boolenum DEFAULT 'n' NOT NULL,
     ctime  bigint DEFAULT NULL,


### PR DESCRIPTION
Fixes: #23

**Problem**

When using multiple OIDC providers (e.g. two Keycloak realms) in this module, group names are stored globally unique (_uq_oidc_group_name_).
If two providers deliver the same group name, the second login may attempt to insert an already existing group and fails with a duplicate key error.

**Solution**

This PR makes group name handling explicit and safe for multi-provider setups:

- Groups are treated as globally unique by name (matching the existing DB schema).
- Group membership cleanup is scoped to the current provider, preventing unintended removal of memberships originating from other providers.
- Adds a provider-level setting group_mapping_strategy:
  - shared (default): reuse group names across providers (no prefix)
  - prefixed: namespace group names per provider using group_name_prefix (or a default prefix derived from the provider name)
  - This allows mixed setups where some providers share groups and others use prefixed names to avoid collisions.

**Database changes**
- Schema upgrade to 0.6.2 adds tbl_provider.group_mapping_strategy (default shared) for both MySQL and PostgreSQL.

**Testing**

- Verified logins via two providers with identical group claims in shared mode (no duplicate key error).
- Verified prefixed mode creates provider-namespaced groups (custom or default prefix).
- Verified membership cleanup remains provider-scoped.

**Notes**

This PR intentionally does not support duplicate usernames across providers. Usernames are expected to be globally unique.